### PR TITLE
docs: fix rinha-test folder location

### DIFF
--- a/rinha-test/README.md
+++ b/rinha-test/README.md
@@ -10,7 +10,7 @@ Instale o k6 caso ainda já não o tenha feito. Siga as instruções [aqui](http
 
 ### Execução dos Testes
 
-Antes de executar os testes, você precisa subir os containers do seu backend e dos [Payment Processors](../payment-processor/docker-compose.yml). Após ter feito isso, basta entrar no diretório [rinha-test](./rinha-test) e executar o seguinte comando:
+Antes de executar os testes, você precisa subir os containers do seu backend e dos [Payment Processors](../payment-processor/docker-compose.yml). Após ter feito isso, basta entrar no diretório [rinha-test](./) e executar o seguinte comando:
 
 ```shell
 k6 run rinha.js


### PR DESCRIPTION
O arquivo readme já está dentro da pasta `rinha-test` o que gera um 404 quando clicado. 

<img width="1917" height="1011" alt="image" src="https://github.com/user-attachments/assets/c3df8b00-b610-48ef-b769-0273eb0167c3" />
