### PR TITLE
Fix rinha.js para calcular actual_total_ammount com payment fixed ammount

### DIFF
--- a/rinha-test/rinha.js
+++ b/rinha-test/rinha.js
@@ -246,7 +246,7 @@ export async function define_stage() {
 export function handleSummary(data) {
 
   const expected_total_amount = data.metrics.transactions_success.values.count * paymentRequestFixedAmount;
-  const actual_total_amount = data.metrics.total_transactions_amount.values.count;
+  const actual_total_amount = data.metrics.total_transactions_amount.values.count * paymentRequestFixedAmount;
   const difference_total_amount = expected_total_amount - actual_total_amount;
 
   const default_total_fee = data.metrics.default_total_fee.values.count;


### PR DESCRIPTION
Estava verificando os testes e notei que tem uma inconsistencia quando o `actual total ammount` é calculado.
A diferença entre o `expected` e `actual` me parecia errada, pois o `expected` estava considerando o valor total das operações e o `actual` estava considerando apenas a quantidade de operações.