### PR TITLE
[fix calculo incosistencia] o calculo da diferenca gerava multa por c…

### DIFF
--- a/rinha-test/rinha.js
+++ b/rinha-test/rinha.js
@@ -255,7 +255,7 @@ export function handleSummary(data) {
 
   const p_99 = data.metrics["http_req_duration{expected_response:true}"].values["p(99)"];
   const p_99_bonus = Math.max((11 - p_99) * 0.02, 0);
-  const contains_inconsistencies = difference_total_amount != 0 || data.metrics.balance_inconsistency_amount.values.count != 0;
+  const contains_inconsistencies = Math.abs(difference_total_amount) > 0.01;
   const inconsistencies_fine = contains_inconsistencies ? 0.35 : 0;
 
   const liquid_partial_amount = (actual_total_amount - total_fee);


### PR DESCRIPTION
…onta de problemas nas contas com ponto flutante. Acrescentei um respiro de 0,01. Acho que não muda muito o espirito e previne penalizacoes que talvessem nao devessem acontecer

Em uma dos testes que rodei tive esse resultado:

```
{
  "participante": "anonymous",
  "descricao": "'total_liquido' é sua pontuação final. Equivale ao seu lucro. Fórmula: total_liquido + (total_liquido * p99.bonus) - (total_liquido * multa.porcentagem)",
  "total_liquido": 282433.735,
  "total_bruto": 301226.3,
  "total_taxas": 18792.565000000002,
  "p99": {
    "valor": "68.43079999999999ms",
    "bonus": 0,
    "max_requests": 500,
    "descricao": "Fórmula para o bônus: max((11 - p99.valor) * 0.02, 0)"
  },
  "multa": {
    "porcentagem": 0,
    "total": 0,
    "composicao": {
      "descricao": "Se 'total_bruto' != 'total_bruto_esperado' ou 'total_inconsistencias' > 0, há multa de 35%.",
      "total_bruto_esperado": 301226.3,
      "total_inconsistencias": 218.9
    }
  },
  "pagamentos": {
    "qtd_sucesso": 15137,
    "qtd_falha": 0
  },
  "default": {
    "total_bruto": 263913.8,
    "num_pagamentos": 13262,
    "total_taxas": 13195.69
  },
  "fallback": {
    "total_bruto": 37312.5,
    "num_pagamentos": 1875,
    "total_taxas": 5596.875
  }
}
```

O total bruto e o total bruto esperado parecem o mesmo, mas a conta traz diferença. Eu acho que é problema de precisão por conta da forma de calculo... Deixei um respiro para lidar com o problema. 