### PR TITLE
fix: ensure NGINX waits for backend services before starting

### DIFF
--- a/participantes/leonardotomas-cs/docker-compose.yml
+++ b/participantes/leonardotomas-cs/docker-compose.yml
@@ -38,20 +38,6 @@ services:
           cpus: "0.1"
           memory: "20MB"
 
-  nginx:
-    image: nginx:latest
-    networks:
-      - rinha
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-    ports:
-      - "9999:9999"
-    deploy:
-      resources:
-        limits:
-          cpus: "0.1"
-          memory: "15MB"
-
   rinhabackend01: &backend-template
     image: leo9114/rinha-de-backend-2025-csharp:latest
     networks:
@@ -78,6 +64,30 @@ services:
     <<: *backend-template
     ports:
       - "8089:80"
+
+  nginx:
+    image: nginx:latest
+    networks:
+      - rinha
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "9999:9999"
+    depends_on:
+      - rinhabackend01
+      - rinhabackend02
+    deploy:
+      resources:
+        limits:
+          cpus: "0.1"
+          memory: "15MB"
+    restart: unless-stopped
+    command: >
+      sh -c "
+        echo 'Waiting for backends to be ready...' &&
+        sleep 10 &&
+        nginx -g 'daemon off;'
+      "
 
 networks:
   rinha:


### PR DESCRIPTION
**Por favor, marque com um `x` os requisitos que atendeu antes de prosseguir com o pull request.**

Obrigado por participar da Rinha de Backend!

- [x] Incluí um README.md com informações sobre minha participação.
- [x] O arquivo `docker-compose.yml` está na raiz do meu diretório.
- [x] Eu não incluí um arquivo `partial-results.json`, `k6.logs` e/ou `docker-compose.logs` no meu PR.
- [x] Não ultrapassei os limites de memória (350MB) e CPU (1.5).
- [x] Não estou incluindo arquivos desnecessários para a execução do teste no meu pull request tais como código fonte, scripts, e excesso de imagens.
- [x] Não estou alterando arquivos fora do ou dos meus diretórios de participação.
- [x] Testei pelo menos o funcionamento básico do `docker-compose.yml`, todos os serviços estão subindo e minha API respondendo na porta 9999.
- [x] Todas imagens contidas no `docker-compose.yml` funcionam na arquitetura linux/amd64.

*Obs.: Se for uma alteração da sua submissão, você pode remover os arquivos `docker-compose.logs`, `k6.logs` e `partial-results.json` para que seu backend seja testado novamente.*
