### PR TITLE
build(test-runner): ensure use of latest Docker images

### DIFF
--- a/rinha-test/run-tests.sh
+++ b/rinha-test/run-tests.sh
@@ -7,7 +7,7 @@ startContainers() {
     pushd ../participantes/$1 > /dev/null
         services=$(docker compose config --services | wc -l)
         echo "" > docker-compose.logs
-        nohup docker compose up --build >> docker-compose.logs &
+        nohup docker compose up --build --force-recreate --pull always >> docker-compose.logs &
     popd > /dev/null
     #expectedServicesUp=$(( services + 4 ))
     #servicesUp=$(docker ps | grep ' Up ' | wc -l)


### PR DESCRIPTION
Boa noite, @zanfranceschi\! Tudo bem?

Estou abrindo este PR para sugerir uma pequena alteração no script de execução dos testes.

#### O Problema

Atualmente, o script utiliza o comando `docker compose up --build`. Embora o `--build` reconstrua a imagem da aplicação se o `Dockerfile` mudar, ele **não garante que a imagem base** (declarada na instrução `FROM`) seja a mais recente. Por padrão, o Docker utiliza a versão da imagem base que ele possui em cache local.

Percebi este cenário ocorrendo na minha própria solução. Eu publico minha imagem de aplicação com a tag `:latest` e, ao enviar uma nova versão para o registry, notei que o script de avaliação continuava executando os testes contra a versão antiga que estava em cache, sem baixar a mais nova. Isso pode mascarar problemas ou gerar resultados inconsistentes, já que o ambiente de teste não seria o mais atual.

#### A Solução Proposta

A mudança proposta é adicionar o parâmetro `--pull always` ao comando `docker compose up`. O comando ficaria assim:

```diff
- nohup docker compose up --build >> docker-compose.logs &
+ nohup docker compose up --build --pull always >> docker-compose.logs &
```

Este parâmetro força o Docker a sempre verificar e baixar a versão mais recente das imagens referenciadas no `docker-compose.yml` antes de iniciar os contêineres.

Isso garante que cada execução utilize as dependências e o ambiente mais atualizados, tornando o processo de teste mais confiável e justo para todos os participantes.

O que você acha, faz sentido essa alteração? Acredito que seja uma melhoria valiosa para o teste.

Abraços\!