### PR TITLE
Ajustes no mini-guia

### DIFF
--- a/payment-processor/docker-compose.yml
+++ b/payment-processor/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - 8001:8080
     depends_on:
       - payment-processor-db-1
-    
+
   payment-processor-db-1:
     <<: *payment-processor-db
     container_name: payment-processor-default-db
@@ -62,7 +62,7 @@ services:
       - payment-processor-db
     depends_on:
       - payment-processor-db-2
-  
+
   payment-processor-db-2:
     <<: *payment-processor-db
     container_name: payment-processor-fallback-db

--- a/rinha-test/MINIGUIA.md
+++ b/rinha-test/MINIGUIA.md
@@ -22,11 +22,9 @@ Essa ferramenta [será utilizada para testar requisições na sua API local](htt
 
 Siga as [instruções para instalar no seu sistema operacional](https://grafana.com/docs/k6/latest/set-up/install-k6/) e depois vá para a pasta `rinha-test` para rodar o teste com `k6 run rinha.js` — mas não agora, tem algumas coisas que ainda serão resolvidas logo abaixo.
 
-### 3. Crie rotas necessárias para rodar o teste
+### 3. Seu Backend
 
-Além dos [endpoints a serem desenvolvidos](https://github.com/zanfranceschi/rinha-de-backend-2025/tree/main#resumo-dos-endpoints), há também um *endpoint secreto* necessário para o script não crashar, que é o `POST /purge-payments`. Ele é chamado pelo script de teste e serve para notificar uma limpeza no seu serviço.
-
-[Seu backend também deve estar exposto na porta `9999`.](https://github.com/zanfranceschi/rinha-de-backend-2025?tab=readme-ov-file#arquitetura)
+Sinta-se livre para criar o seu backend com os [endpoints](https://github.com/zanfranceschi/rinha-de-backend-2025/blob/main/INSTRUCOES.md#detalhes-dos-endpoints) necessários.
 
 Se por algum motivo você quiser testar apenas um cenário, comente os demais no arquivo [`rinha.js`](https://github.com/zanfranceschi/rinha-de-backend-2025/blob/2ac3f62f225afd6748e9164be3c4d4ebe5d3474e/rinha-test/rinha.js#L35-L128).
 

--- a/rinha-test/MINIGUIA.md
+++ b/rinha-test/MINIGUIA.md
@@ -14,11 +14,11 @@ Docker será utilizado do início ao final do projeto para que haja um ambiente 
 
 [Depois de instalado](https://docs.docker.com/get-started/get-docker/) vá até a pasta `payment-processor` e rode `docker compose up` para inicializar os servidores do payment processor.
 
-Se tudo ocorrer como esperado, o servidor default (http://127.0.0.1:8001/) e de fallback (http://127.0.0.1:8002/) estarão online e com [seus endpoints](https://github.com/zanfranceschi/rinha-de-backend-2025/tree/main#resumo-dos-endpoints) funcionando bonitinho.
+Se tudo ocorrer como esperado, o servidor default (http://127.0.0.1:8001/) e de fallback (http://127.0.0.1:8002/) estarão online e com [seus endpoints](https://github.com/zanfranceschi/rinha-de-backend-2025/blob/main/INSTRUCOES.md#detalhes-dos-endpoints) funcionando bonitinho.
 
 ### 2. K6
 
-Essa ferramenta [será utilizada para testar requisições na sua API local](https://github.com/zanfranceschi/rinha-de-backend-2025/tree/main/rinha-test). Assim, você poderá validar se seu backend está processando as informações direitinho e tankando o estresse.
+Essa ferramenta [será utilizada para testar requisições na sua API local](https://github.com/zanfranceschi/rinha-de-backend-2025/tree/main/rinha-test#instru%C3%A7%C3%B5es-para-execu%C3%A7%C3%A3o-dos-testes-locais). Assim, você poderá validar se seu backend está processando as informações direitinho e tankando o estresse.
 
 Siga as [instruções para instalar no seu sistema operacional](https://grafana.com/docs/k6/latest/set-up/install-k6/) e depois vá para a pasta `rinha-test` para rodar o teste com `k6 run rinha.js` — mas não agora, tem algumas coisas que ainda serão resolvidas logo abaixo.
 


### PR DESCRIPTION
## Ajustes no mini-guia.

### O que foi feito?
- Corrige links errados para outros guias do projeto;
- Remove informação errada que deixa a entender que o participante deveria criar um endpoint `POST /purge-payments` para "notificar uma limpeza no seu serviço";
- Remove espaços vazios no _docker-compose.yml_.