### PR TITLE
Removing error logs pq o docker ratao alcancou o limit de pulls

### DIFF
--- a/participantes/murilo-guedes-toloni/docker-compose.logs
+++ b/participantes/murilo-guedes-toloni/docker-compose.logs
@@ -1,4 +1,0 @@
-
- api1 Pulling 
- api2 Pulling 
-toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit

--- a/participantes/murilo-guedes-toloni/error.logs
+++ b/participantes/murilo-guedes-toloni/error.logs
@@ -1,2 +1,0 @@
-[Tue Jul 29 10:49:03 PM -03 2025] Seu backend não respondeu nenhuma das 15 tentativas de GET para http://localhost:9999/payments-summary. Teste abortado.
-[Tue Jul 29 10:49:03 PM -03 2025] Inspecione o arquivo docker-compose.logs para mais informações.


### PR DESCRIPTION
**Por favor, marque com um `x` os requisitos que atendeu antes de prosseguir com o pull request.**

Obrigado por participar da Rinha de Backend!

- [x] Incluí um README.md com informações sobre minha participação.
- [x] O arquivo `docker-compose.yml` está na raiz do meu diretório.
- [x] Eu não incluí um arquivo `partial-results.json`, `k6.logs` e/ou `docker-compose.logs` no meu PR.
- [x] Não ultrapassei os limites de memória (350MB) e CPU (1.5).
- [x] Não estou incluindo arquivos desnecessários para a execução do teste no meu pull request tais como código fonte, scripts, e excesso de imagens.
- [x] Não estou alterando arquivos fora do ou dos meus diretórios de participação.
- [x] Testei pelo menos o funcionamento básico do `docker-compose.yml`, todos os serviços estão subindo e minha API respondendo na porta 9999.
- [x] Todas imagens contidas no `docker-compose.yml` funcionam na arquitetura linux/amd64.

*Obs.: Se for uma alteração da sua submissão, você pode remover os arquivos `docker-compose.logs`, `k6.logs` e `partial-results.json` para que seu backend seja testado novamente.*
