### PR TITLE
retest: o burrão aqui esqueceu de criar uma imagem docker com a tag l…

### DIFF
--- a/participantes/juliotsutsui-go/docker-compose.logs
+++ b/participantes/juliotsutsui-go/docker-compose.logs
@@ -1,6 +1,0 @@
-
- api01 Pulling 
- api02 Pulling 
- api02 Error manifest for jtsutsui/rinha-2025-payment-processor:latest not found: manifest unknown: manifest unknown
- api01  Interrupted
-Error response from daemon: manifest for jtsutsui/rinha-2025-payment-processor:latest not found: manifest unknown: manifest unknown

--- a/participantes/juliotsutsui-go/error.logs
+++ b/participantes/juliotsutsui-go/error.logs
@@ -1,2 +1,0 @@
-[Sun Aug 17 00:55:50 UTC 2025] Seu backend não respondeu nenhuma das 15 tentativas de GET para http://localhost:9999/payments-summary. Teste abortado.
-[Sun Aug 17 00:55:50 UTC 2025] Inspecione o arquivo docker-compose.logs para mais informações.


### PR DESCRIPTION
…atest

**Por favor, marque com um `x` os requisitos que atendeu antes de prosseguir com o pull request.**

Obrigado por participar da Rinha de Backend!

- [x] Incluí um README.md com informações sobre minha participação.
- [x] O arquivo `docker-compose.yml` está na raiz do meu diretório.
- [x] Eu não incluí um arquivo `partial-results.json`, `k6.logs` e/ou `docker-compose.logs` no meu PR.
- [x] Não ultrapassei os limites de memória (350MB) e CPU (1.5).
- [x] Não estou incluindo arquivos desnecessários para a execução do teste no meu pull request tais como código fonte, scripts, e excesso de imagens.
- [x] Não estou alterando arquivos fora do ou dos meus diretórios de participação.
- [x] Testei pelo menos o funcionamento básico do `docker-compose.yml`, todos os serviços estão subindo e minha API respondendo na porta 9999.
- [x] Todas as imagens contidas no `docker-compose.yml` funcionam na arquitetura linux/amd64.

*Obs.: Se for uma alteração da sua submissão, você pode remover os arquivos `docker-compose.logs`, `k6.logs` e `partial-results.json` para que seu backend seja testado novamente.*
